### PR TITLE
ログインフォームのバリデーションを変更

### DIFF
--- a/lib/screens/account/account_login_screen.dart
+++ b/lib/screens/account/account_login_screen.dart
@@ -81,15 +81,11 @@ class AccountLoginScreen extends HookConsumerWidget {
                       decoration: InputDecoration(
                         hintText: '新しいログインID'.i18n,
                       ),
-                      onChanged: (value) {
+                      onValidate: (valid, id) {
                         //setState() or markNeedsBuild() called during buildを防ぐため
                         WidgetsBinding.instance.addPostFrameCallback((_) {
-                          newID.value = value;
-                        });
-                      },
-                      onValidate: (valid) {
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
                           isValidID.value = valid;
+                          newID.value = id;
                         });
                       },
                     ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -56,15 +56,11 @@ class LoginScreen extends HookConsumerWidget {
                             borderRadius: BorderRadius.circular(40),
                           ),
                         ),
-                        onChanged: (value) {
+                        onValidate: (valid, id) {
                           //setState() or markNeedsBuild() called during buildを防ぐため
                           WidgetsBinding.instance.addPostFrameCallback((_) {
-                            idInput.value = value;
-                          });
-                        },
-                        onValidate: (valid) {
-                          WidgetsBinding.instance.addPostFrameCallback((_) {
                             isValidID.value = valid;
+                            idInput.value = id;
                           });
                         }),
                     const SizedBox(height: 16),

--- a/lib/widgets/form/login_id_form.dart
+++ b/lib/widgets/form/login_id_form.dart
@@ -6,14 +6,12 @@ class LoginIDForm extends StatefulWidget {
   const LoginIDForm({
     Key? key,
     required this.readOnly,
-    required this.onChanged,
     required this.onValidate,
     required this.decoration,
   }) : super(key: key);
 
   final bool readOnly;
-  final Function(String value) onChanged;
-  final Function(bool valid) onValidate;
+  final Function(bool valid, String id) onValidate;
   final InputDecoration decoration;
 
   @override
@@ -34,19 +32,16 @@ class _LoginIDFormState extends State<LoginIDForm> {
         ),
       ],
       autovalidateMode: AutovalidateMode.onUserInteraction,
-      onChanged: (value) {
-        widget.onChanged(value);
-      },
       validator: (value) {
         if (value!.length < 4 || 14 < value.length) {
-          widget.onValidate(false);
+          widget.onValidate(false, value);
           return 'IDは4文字以上14文字以下である必要があります'.i18n;
         }
         if (!value.contains(RegExp(r'[a-z]'))) {
-          widget.onValidate(false);
+          widget.onValidate(false, value);
           return 'IDにはアルファベットが含まれている必要があります'.i18n;
         }
-        widget.onValidate(true);
+        widget.onValidate(true, value);
         return null;
       },
     ));


### PR DESCRIPTION
下記の条件を設定した、新しいログインフォームを作成しました。
- 4文字以上14文字以下
- アンダースコア・アットマーク利用可
- アルファベットは小文字のみ
- アルファベット一文字以上必須

ID変更画面では、上記条件を満たしている時のみ「更新」ボタンが押せるように変更しました。
また、ログイン画面では、上記条件を満たしていて、かつパスワードが一文字以上入力されている時のみログインボタンが押せるように変更しました。

下記はID変更画面でのバリデーションのサンプルです。
![スクリーンショット 2023-08-04 0 17 52](https://github.com/aipictors/aipictors-flutter/assets/104188098/9fa084fe-8287-4436-8d67-ffb90f84bc43)
![スクリーンショット 2023-08-04 0 18 03](https://github.com/aipictors/aipictors-flutter/assets/104188098/eb778bdf-ee4a-4a03-99e9-89f62b1f490e)
![スクリーンショット 2023-08-04 0 18 23](https://github.com/aipictors/aipictors-flutter/assets/104188098/d08775a8-4852-40bb-80f4-aed734abd06a)
