### PR TITLE
update: キャッシュクリア時、DefaultCacheManagerのキャッシュも削除する

### DIFF
--- a/lib/screens/config/config_screen.dart
+++ b/lib/screens/config/config_screen.dart
@@ -11,6 +11,7 @@ import 'package:aipictors/widgets/dialog/about_twitter_dialog.dart';
 import 'package:aipictors/widgets/dialog/logout_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -427,6 +428,7 @@ class ConfigScreen extends HookConsumerWidget {
 
   Future onClearCache(BuildContext context) async {
     HiveRepository.clear();
+    DefaultCacheManager().emptyCache();
     ScaffoldMessenger.of(context)
       ..hideCurrentSnackBar()
       ..showSnackBar(


### PR DESCRIPTION
fix #128 
GraphQLのキャッシュはHiveが、画像のキャッシュはDefaultCacheManagerが持っているにも関わらず、キャッシュクリア時にはHiveのキャッシュしかクリアされていないようだったので、DefaultCacheManagerのキャッシュも削除するように変更しました。