### PR TITLE
update: 新バージョンがある場合、更新を促すダイアログを表示する

### DIFF
--- a/lib/providers/is_update_dialog_showed_provider.dart
+++ b/lib/providers/is_update_dialog_showed_provider.dart
@@ -1,0 +1,15 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'is_update_dialog_showed_provider.g.dart';
+
+@riverpod
+class IsUpdateDialogShowed extends _$IsUpdateDialogShowed {
+  @override
+  bool build() {
+    return false;
+  }
+
+  void update(bool n) {
+    state = n;
+  }
+}

--- a/lib/providers/is_update_dialog_showed_provider.g.dart
+++ b/lib/providers/is_update_dialog_showed_provider.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'is_update_dialog_showed_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$isUpdateDialogShowedHash() =>
+    r'77a9f45d6c8b3d5f11d3269c9e0aef00a44319a5';
+
+/// See also [IsUpdateDialogShowed].
+@ProviderFor(IsUpdateDialogShowed)
+final isUpdateDialogShowedProvider =
+    AutoDisposeNotifierProvider<IsUpdateDialogShowed, bool>.internal(
+  IsUpdateDialogShowed.new,
+  name: r'isUpdateDialogShowedProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$isUpdateDialogShowedHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$IsUpdateDialogShowed = AutoDisposeNotifier<bool>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/widgets/dialog/latest_version_dialog.dart
+++ b/lib/widgets/dialog/latest_version_dialog.dart
@@ -24,7 +24,7 @@ class LatestVersionDialog extends HookConsumerWidget {
             foregroundColor: Theme.of(context).colorScheme.error,
           ),
           onPressed: onAccept,
-          child: Text('削除する'.i18n),
+          child: Text('更新する'.i18n),
         ),
         TextButton(
           onPressed: onCancel,


### PR DESCRIPTION
新バージョンがある場合、起動時に更新を促すダイアログを表示するように変更しました。
スマホではデバッグしたのですが、明日iPadでも確認してみます。